### PR TITLE
Fix: the wrong hostname was being passed in to the API client

### DIFF
--- a/pkg/cmd/attestation/api/client.go
+++ b/pkg/cmd/attestation/api/client.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	ioconfig "github.com/cli/cli/v2/pkg/cmd/attestation/io"
 	"github.com/cli/go-gh/v2/pkg/auth"
 )
@@ -35,11 +34,10 @@ type LiveClient struct {
 
 func NewLiveClient(hc *http.Client, l *ioconfig.Handler) *LiveClient {
 	host, _ := auth.DefaultHost()
-	serverURL := ghinstance.HostPrefix(host)
 
 	return &LiveClient{
 		api:    api.NewClientFromHTTP(hc),
-		host:   strings.TrimSuffix(serverURL, "/"),
+		host:   strings.TrimSuffix(host, "/"),
 		logger: l,
 	}
 }


### PR DESCRIPTION
Hi!

I wonder why wasn't this caught by our test suite / could you please add a test that fails and or would catch this?

The issue I experienced boiled down to `LiveClient.host` expecting a FQDN ("github.com"), and **not** a URL ("https://github.com").

Before:

```
$ make && GH_DEBUG=1 ./bin/gh attestation verify ~/Downloads/gh-attestation-darwin-amd64 --owner github
Verifying attestations for the artifact found at file:///Users/phillmv/Downloads/gh-attestation-darwin-amd64
Fetching attestations for artifact digest sha256:85cd8648c262697d9a0beb7e4c934839f65677f74263f2f5e1584ff0b2098c38

* Request at 2024-03-22 15:41:53.223129 -0400 EDT m=+0.166123962
* Request to https://https//github.com/api/v3/orgs/github/attestations/sha256:85cd8648c262697d9a0beb7e4c934839f65677f74263f2f5e1584ff0b2098c38?per_page=30
* dial tcp: lookup https: no such host
* Request took 4.577123ms
Failed to verify the artifact: failed to fetch attestations for subject: sha256:85cd8648c262697d9a0beb7e4c934839f65677f74263f2f5e1584ff0b2098c38
```

after:

```
$ make && GH_DEBUG=1 ./bin/gh attestation verify ~/Downloads/gh-attestation-darwin-amd64 --owner github
go build -trimpath -ldflags "-X github.com/cli/cli/v2/internal/build.Date=2024-03-22 -X github.com/cli/cli/v2/internal/build.Version=c16406b6 " -o bin/gh ./cmd/gh
Verifying attestations for the artifact found at file:///Users/phillmv/Downloads/gh-attestation-darwin-amd64
Fetching attestations for artifact digest sha256:85cd8648c262697d9a0beb7e4c934839f65677f74263f2f5e1584ff0b2098c38

* Request at 2024-03-22 15:42:34.047832 -0400 EDT m=+0.131718995
* Request to https://api.github.com/orgs/github/attestations/sha256:85cd8648c262697d9a0beb7e4c934839f65677f74263f2f5e1584ff0b2098c38?per_page=30
* Request took 287.862655ms
Verifying attestation 1/1 against the configured Sigstore trust roots
Attempting verification against issuer "GitHub, Inc."
SUCCESS - attestation signature verified with "GitHub, Inc."

Successfully verified all attestations against Sigstore!

Evaluating attestations have valid SLSA predicate type
Successfully verified the SLSA predicate type of all attestations!

All attestations have been successfully verified!
```